### PR TITLE
Ensure related entities are eagerly loaded

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
 
 		<spring.version>4.2.0.RELEASE</spring.version>
 		<spring.data.jpa.version>1.8.2.RELEASE</spring.data.jpa.version>
-		<hibernate.version>4.3.10.Final</hibernate.version>
+		<hibernate.version>4.3.11.Final</hibernate.version>
 		<hibernate.validator.version>5.2.0.Final</hibernate.validator.version>
 		<jackson.version>2.6.0</jackson.version>
 		<javax.el.api.version>2.2.5</javax.el.api.version>

--- a/src/test/java/org/springframework/data/jpa/datatables/Config.java
+++ b/src/test/java/org/springframework/data/jpa/datatables/Config.java
@@ -5,7 +5,9 @@ import java.util.Properties;
 
 import javax.sql.DataSource;
 
+import org.hibernate.SessionFactory;
 import org.hibernate.cfg.Environment;
+import org.hibernate.jpa.HibernateEntityManagerFactory;
 import org.hibernate.tool.hbm2ddl.MultipleLinesSqlCommandExtractor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -60,4 +62,10 @@ public class Config {
 
     return bean;
   }
+
+  @Bean
+  public SessionFactory sessionFactory() throws SQLException {
+    return ((HibernateEntityManagerFactory) entityManagerFactory().getObject()).getSessionFactory();
+  }
+
 }

--- a/src/test/resources/log4j.properties
+++ b/src/test/resources/log4j.properties
@@ -5,3 +5,4 @@ log4j.appender.console.layout.ConversionPattern=%d{ABSOLUTE} %5p %40.40c:%4L - %
 log4j.appender.console=org.apache.log4j.ConsoleAppender
 
 log4j.logger.org.springframework=INFO
+log4j.logger.org.hibernate.SQL=DEBUG


### PR DESCRIPTION
Even with `@ManyToOne(fetch = FetchType.EAGER)`, the associated entities were not eagerly loaded, resulting in additional queries.

The bump of hibernate version is linked to https://hibernate.atlassian.net/browse/HHH-9637.