### PR TITLE
Restrict eager loading to @OneToOne and @OneToMany relationships

### DIFF
--- a/src/main/java/org/springframework/data/jpa/datatables/repository/SpecificationFactory.java
+++ b/src/main/java/org/springframework/data/jpa/datatables/repository/SpecificationFactory.java
@@ -111,8 +111,10 @@ class SpecificationFactory {
           continue;
         }
         String[] values = column.getData().split(ESCAPED_ATTRIBUTE_SEPARATOR);
-        if (root.getModel().getAttribute(values[0])
-            .getPersistentAttributeType() == PersistentAttributeType.EMBEDDED) {
+        PersistentAttributeType type =
+            root.getModel().getAttribute(values[0]).getPersistentAttributeType();
+        if (type != PersistentAttributeType.ONE_TO_ONE
+            && type != PersistentAttributeType.MANY_TO_ONE) {
           continue;
         }
         Fetch<?, ?> fetch = null;


### PR DESCRIPTION
Previously, a JOIN FETCH was also added when dealing with a
relationship that may return multiple lines (@OneToMany, for example).
Since Hibernate doesn't know how many lines it will need to construct
your entities, it fetches a lot of lines and store them in memory,
resulting in a big performance hit. In that case, the following warning
is dislayed: "HHH000104: firstResult/maxResults specified with
collection fetch; applying in memory!". That commit thus restricts JOIN
FETCH to @OneToOne and @ManyToOne relationships.

Fixes #38 