### PR TITLE
Add null filter

### DIFF
--- a/src/main/java/org/springframework/data/jpa/datatables/repository/DataTablesUtils.java
+++ b/src/main/java/org/springframework/data/jpa/datatables/repository/DataTablesUtils.java
@@ -17,6 +17,8 @@ public class DataTablesUtils {
   public final static String ATTRIBUTE_SEPARATOR = ".";
   public final static String ESCAPED_ATTRIBUTE_SEPARATOR = "\\.";
   public final static char ESCAPE_CHAR = '\\';
+  public final static String NULL = "NULL";
+  public final static String ESCAPED_NULL = "\\NULL";
 
   /**
    * Creates a 'LIMIT .. OFFSET .. ORDER BY ..' clause for the given {@link DataTablesInput}.

--- a/src/test/java/org/springframework/data/jpa/datatables/qrepository/QBillRepositoryTest.java
+++ b/src/test/java/org/springframework/data/jpa/datatables/qrepository/QBillRepositoryTest.java
@@ -45,6 +45,28 @@ public class QBillRepositoryTest {
   }
 
   @Test
+  public void testBooleanFilterAndNull() {
+    DataTablesInput input = getBasicInput();
+
+    input.getColumn("hasBeenPayed").setSearchValue("TRUE+NULL");
+    DataTablesOutput<Bill> output = billRepository.findAll(input);
+    assertNotNull(output);
+    assertNull(output.getError());
+    assertEquals(7, output.getRecordsFiltered());
+  }
+
+  @Test
+  public void testFilterIsNull() {
+    DataTablesInput input = getBasicInput();
+
+    input.getColumn("hasBeenPayed").setSearchValue("NULL");
+    DataTablesOutput<Bill> output = billRepository.findAll(input);
+    assertNotNull(output);
+    assertNull(output.getError());
+    assertEquals(1, output.getRecordsFiltered());
+  }
+
+  @Test
   public void testBooleanFilter2() {
     DataTablesInput input = getBasicInput();
 

--- a/src/test/java/org/springframework/data/jpa/datatables/qrepository/QBillRepositoryTest.java
+++ b/src/test/java/org/springframework/data/jpa/datatables/qrepository/QBillRepositoryTest.java
@@ -29,8 +29,8 @@ public class QBillRepositoryTest {
     DataTablesOutput<Bill> output = billRepository.findAll(input);
     assertNotNull(output);
     assertNull(output.getError());
-    assertEquals(12, output.getRecordsFiltered());
-    assertEquals(12, output.getRecordsTotal());
+    assertEquals(13, output.getRecordsFiltered());
+    assertEquals(13, output.getRecordsTotal());
   }
 
   @Test

--- a/src/test/java/org/springframework/data/jpa/datatables/qrepository/QUserRepositoryTest.java
+++ b/src/test/java/org/springframework/data/jpa/datatables/qrepository/QUserRepositoryTest.java
@@ -177,6 +177,46 @@ public class QUserRepositoryTest {
   }
 
   @Test
+  @Ignore
+  public void testNullColumnFilter() {
+    DataTablesInput input = getBasicInput();
+    input.getColumn("home.town").setSearchValue("town0+NULL");
+
+    DataTablesOutput<User> output = userRepository.findAll(input);
+    assertNotNull(output);
+    assertEquals(1, output.getDraw());
+    assertNull(output.getError());
+    assertEquals(10, output.getRecordsFiltered());
+    assertEquals(24, output.getRecordsTotal());
+  }
+
+  @Test
+  public void testEscapedOrNull() {
+    DataTablesInput input = getBasicInput();
+    input.getColumn("home.town").setSearchValue("town0+\\NULL");
+
+    DataTablesOutput<User> output = userRepository.findAll(input);
+    assertNotNull(output);
+    assertEquals(1, output.getDraw());
+    assertNull(output.getError());
+    assertEquals(6, output.getRecordsFiltered());
+    assertEquals(24, output.getRecordsTotal());
+  }
+
+  @Test
+  public void testEscapedNull() {
+    DataTablesInput input = getBasicInput();
+    input.getColumn("home.town").setSearchValue("\\NULL");
+
+    DataTablesOutput<User> output = userRepository.findAll(input);
+    assertNotNull(output);
+    assertEquals(1, output.getDraw());
+    assertNull(output.getError());
+    assertEquals(1, output.getRecordsFiltered());
+    assertEquals(24, output.getRecordsTotal());
+  }
+
+  @Test
   public void testMultiFilterOnSameColumn() {
     DataTablesInput input = getBasicInput();
 

--- a/src/test/java/org/springframework/data/jpa/datatables/repository/BillRepositoryTest.java
+++ b/src/test/java/org/springframework/data/jpa/datatables/repository/BillRepositoryTest.java
@@ -42,6 +42,7 @@ public class BillRepositoryTest {
     DataTablesOutput<Bill> output = billRepository.findAll(input);
     assertNotNull(output);
     assertNull(output.getError());
+    assertEquals(6, output.getRecordsFiltered());
   }
 
   @Test

--- a/src/test/java/org/springframework/data/jpa/datatables/repository/BillRepositoryTest.java
+++ b/src/test/java/org/springframework/data/jpa/datatables/repository/BillRepositoryTest.java
@@ -49,7 +49,7 @@ public class BillRepositoryTest {
   public void testBooleanFilterAndNull() {
     DataTablesInput input = getBasicInput();
 
-    input.getColumn("hasBeenPayed").setSearchValue("TRUE+" + SpecificationFactory.ISNULL);
+    input.getColumn("hasBeenPayed").setSearchValue("TRUE+NULL");
     DataTablesOutput<Bill> output = billRepository.findAll(input);
     assertNotNull(output);
     assertNull(output.getError());
@@ -60,7 +60,7 @@ public class BillRepositoryTest {
   public void testFilterIsNull() {
     DataTablesInput input = getBasicInput();
 
-    input.getColumn("hasBeenPayed").setSearchValue(SpecificationFactory.ISNULL);
+    input.getColumn("hasBeenPayed").setSearchValue("NULL");
     DataTablesOutput<Bill> output = billRepository.findAll(input);
     assertNotNull(output);
     assertNull(output.getError());

--- a/src/test/java/org/springframework/data/jpa/datatables/repository/BillRepositoryTest.java
+++ b/src/test/java/org/springframework/data/jpa/datatables/repository/BillRepositoryTest.java
@@ -30,8 +30,8 @@ public class BillRepositoryTest {
     DataTablesOutput<Bill> output = billRepository.findAll(input);
     assertNotNull(output);
     assertNull(output.getError());
-    assertEquals(12, output.getRecordsFiltered());
-    assertEquals(12, output.getRecordsTotal());
+    assertEquals(13, output.getRecordsFiltered());
+    assertEquals(13, output.getRecordsTotal());
   }
 
   @Test
@@ -42,7 +42,28 @@ public class BillRepositoryTest {
     DataTablesOutput<Bill> output = billRepository.findAll(input);
     assertNotNull(output);
     assertNull(output.getError());
-    assertEquals(6, output.getRecordsFiltered());
+  }
+
+  @Test
+  public void testBooleanFilterAndNull() {
+    DataTablesInput input = getBasicInput();
+
+    input.getColumn("hasBeenPayed").setSearchValue("TRUE+" + SpecificationFactory.ISNULL);
+    DataTablesOutput<Bill> output = billRepository.findAll(input);
+    assertNotNull(output);
+    assertNull(output.getError());
+    assertEquals(7, output.getRecordsFiltered());
+  }
+
+  @Test
+  public void testFilterIsNull() {
+    DataTablesInput input = getBasicInput();
+
+    input.getColumn("hasBeenPayed").setSearchValue(SpecificationFactory.ISNULL);
+    DataTablesOutput<Bill> output = billRepository.findAll(input);
+    assertNotNull(output);
+    assertNull(output.getError());
+    assertEquals(1, output.getRecordsFiltered());
   }
 
   @Test

--- a/src/test/java/org/springframework/data/jpa/datatables/repository/UserRepositoryTest.java
+++ b/src/test/java/org/springframework/data/jpa/datatables/repository/UserRepositoryTest.java
@@ -175,6 +175,19 @@ public class UserRepositoryTest {
   }
 
   @Test
+  public void testNullColumnFilter() {
+    DataTablesInput input = getBasicInput();
+    input.getColumn("home.town").setSearchValue("town0+" + SpecificationFactory.ISNULL);
+
+    DataTablesOutput<User> output = userRepository.findAll(input);
+    assertNotNull(output);
+    assertEquals(1, output.getDraw());
+    assertNull(output.getError());
+    assertEquals(10, output.getRecordsFiltered());
+    assertEquals(24, output.getRecordsTotal());
+  }
+
+  @Test
   public void testMultiFilterOnSameColumn() {
     DataTablesInput input = getBasicInput();
 

--- a/src/test/java/org/springframework/data/jpa/datatables/repository/UserRepositoryTest.java
+++ b/src/test/java/org/springframework/data/jpa/datatables/repository/UserRepositoryTest.java
@@ -177,7 +177,7 @@ public class UserRepositoryTest {
   @Test
   public void testNullColumnFilter() {
     DataTablesInput input = getBasicInput();
-    input.getColumn("home.town").setSearchValue("town0+" + SpecificationFactory.ISNULL);
+    input.getColumn("home.town").setSearchValue("town0+NULL");
 
     DataTablesOutput<User> output = userRepository.findAll(input);
     assertNotNull(output);
@@ -190,7 +190,7 @@ public class UserRepositoryTest {
   @Test
   public void testEscapedOrNull() {
     DataTablesInput input = getBasicInput();
-    input.getColumn("home.town").setSearchValue("town0+" + SpecificationFactory.ESCAPED_NULL);
+    input.getColumn("home.town").setSearchValue("town0+\\NULL");
 
     DataTablesOutput<User> output = userRepository.findAll(input);
     assertNotNull(output);
@@ -203,7 +203,7 @@ public class UserRepositoryTest {
   @Test
   public void testEscapedNull() {
     DataTablesInput input = getBasicInput();
-    input.getColumn("home.town").setSearchValue(SpecificationFactory.ESCAPED_NULL);
+    input.getColumn("home.town").setSearchValue("\\NULL");
 
     DataTablesOutput<User> output = userRepository.findAll(input);
     assertNotNull(output);

--- a/src/test/java/org/springframework/data/jpa/datatables/repository/UserRepositoryTest.java
+++ b/src/test/java/org/springframework/data/jpa/datatables/repository/UserRepositoryTest.java
@@ -188,6 +188,32 @@ public class UserRepositoryTest {
   }
 
   @Test
+  public void testEscapedOrNull() {
+    DataTablesInput input = getBasicInput();
+    input.getColumn("home.town").setSearchValue("town0+" + SpecificationFactory.ESCAPED_NULL);
+
+    DataTablesOutput<User> output = userRepository.findAll(input);
+    assertNotNull(output);
+    assertEquals(1, output.getDraw());
+    assertNull(output.getError());
+    assertEquals(6, output.getRecordsFiltered());
+    assertEquals(24, output.getRecordsTotal());
+  }
+
+  @Test
+  public void testEscapedNull() {
+    DataTablesInput input = getBasicInput();
+    input.getColumn("home.town").setSearchValue(SpecificationFactory.ESCAPED_NULL);
+
+    DataTablesOutput<User> output = userRepository.findAll(input);
+    assertNotNull(output);
+    assertEquals(1, output.getDraw());
+    assertNull(output.getError());
+    assertEquals(1, output.getRecordsFiltered());
+    assertEquals(24, output.getRecordsTotal());
+  }
+
+  @Test
   public void testMultiFilterOnSameColumn() {
     DataTablesInput input = getBasicInput();
 

--- a/src/test/resources/init.sql
+++ b/src/test/resources/init.sql
@@ -52,7 +52,7 @@ INSERT INTO home (id, town) VALUES
   (2, 'town1'),
   (3, 'town2'),
   (4, 'town3'),
-  (5, null),
+  (5, NULL),
   (6, 'NULL');
 
 INSERT INTO users (id, username, role, status, id_home, visible) VALUES

--- a/src/test/resources/init.sql
+++ b/src/test/resources/init.sql
@@ -30,7 +30,8 @@ INSERT INTO bill (id, description, amount, hasBeenPayed) VALUES
   (9,  'foo9',  900,  false),
   (10, 'foo10', 1000, true),
   (11, 'foo11', 1100, false),
-  (12, 'foo12', 1200, true);
+  (12, 'foo12', 1200, true),
+  (13, 'foo13', 1300, NULL);
 
 INSERT INTO game (id, prize_name) VALUES
   (1,  'prize0'),
@@ -50,7 +51,8 @@ INSERT INTO home (id, town) VALUES
   (1, 'town0'),
   (2, 'town1'),
   (3, 'town2'),
-  (4, 'town3');
+  (4, 'town3'),
+  (5, null);
 
 INSERT INTO users (id, username, role, status, id_home, visible) VALUES
   (1,  'john0',  'ADMIN',  'ACTIVE',  null, true),
@@ -76,4 +78,4 @@ INSERT INTO users (id, username, role, status, id_home, visible) VALUES
   (21, 'john20', 'USER',   'ACTIVE',  1,    true),
   (22, 'john21', 'ADMIN',  'BLOCKED', 2,    false),
   (23, 'john22', 'AUTHOR', 'ACTIVE',  3,    true),
-  (24, 'john23', 'USER',   'BLOCKED', 4,    false);
+  (24, 'john23', 'USER',   'BLOCKED', 5,    false);

--- a/src/test/resources/init.sql
+++ b/src/test/resources/init.sql
@@ -52,7 +52,8 @@ INSERT INTO home (id, town) VALUES
   (2, 'town1'),
   (3, 'town2'),
   (4, 'town3'),
-  (5, null);
+  (5, null),
+  (6, 'NULL');
 
 INSERT INTO users (id, username, role, status, id_home, visible) VALUES
   (1,  'john0',  'ADMIN',  'ACTIVE',  null, true),
@@ -77,5 +78,5 @@ INSERT INTO users (id, username, role, status, id_home, visible) VALUES
   (20, 'john19', 'AUTHOR', 'BLOCKED', 4,    false),
   (21, 'john20', 'USER',   'ACTIVE',  1,    true),
   (22, 'john21', 'ADMIN',  'BLOCKED', 2,    false),
-  (23, 'john22', 'AUTHOR', 'ACTIVE',  3,    true),
+  (23, 'john22', 'AUTHOR', 'ACTIVE',  6,    true),
   (24, 'john23', 'USER',   'BLOCKED', 5,    false);


### PR DESCRIPTION
This change adds the ability to search for null values from a dataTables search string.

For example, say there are 3 possible values for a column: `Sent, Received, Unknown`, yet it is a nullable column.  To find `Sent` and `Unknown` rows the filter is `Sent+Unknown`.  However, NULL could be interpreted as `Unknown` too.  

With this modification you can specify `Sent+Unknown+NULL` to see rows with null values.  In order to look for the text `NULL`, escape the value as `\NULL`.

Changes:

Added a constants for NULL and escaped NULL.
Added code to look for NULL in the list of values and remove it
Added code to look for NULL in a list of boolean tests
Added code to add “column IS NULL” when necessary
Added code to look for NULL as a single value and handle appropriately
Added unit tests to cover all the paths and options