### PR TITLE
[fix] Fix searching with the separator "+"

### DIFF
--- a/src/main/java/org/springframework/data/jpa/datatables/qrepository/PredicateFactory.java
+++ b/src/main/java/org/springframework/data/jpa/datatables/qrepository/PredicateFactory.java
@@ -57,6 +57,12 @@ class PredicateFactory {
             predicate = predicate.and(in);
           }
         } else {
+          if (values.isEmpty()) {
+            if (nullable) {
+              predicate = predicate.and(entity.get(column.getData()).isNull());
+            }
+            continue;
+          }
           Predicate in = getStringExpression(entity, column.getData()).in(values);
           if (nullable) {
             predicate = predicate.and(entity.get(column.getData()).isNull().or(in));

--- a/src/main/java/org/springframework/data/jpa/datatables/repository/SpecificationFactory.java
+++ b/src/main/java/org/springframework/data/jpa/datatables/repository/SpecificationFactory.java
@@ -80,6 +80,12 @@ class SpecificationFactory {
             }
           } else {
             stringExpression = getExpression(root, column.getData(), String.class);
+            if (values.isEmpty()) {
+              if (nullable) {
+                predicate = cb.and(predicate, stringExpression.isNull());
+              }
+              continue;
+            }
             Predicate in = stringExpression.in(values);
             if (nullable) {
               predicate = cb.and(predicate, cb.or(in, stringExpression.isNull()));

--- a/src/test/java/org/springframework/data/jpa/datatables/qrepository/QBillRepositoryTest.java
+++ b/src/test/java/org/springframework/data/jpa/datatables/qrepository/QBillRepositoryTest.java
@@ -67,6 +67,17 @@ public class QBillRepositoryTest {
   }
 
   @Test
+  public void testFilterIsNullWithSeparator() {
+    DataTablesInput input = getBasicInput();
+
+    input.getColumn("hasBeenPayed").setSearchValue("NULL+");
+    DataTablesOutput<Bill> output = billRepository.findAll(input);
+    assertNotNull(output);
+    assertNull(output.getError());
+    assertEquals(1, output.getRecordsFiltered());
+  }
+
+  @Test
   public void testBooleanFilter2() {
     DataTablesInput input = getBasicInput();
 

--- a/src/test/java/org/springframework/data/jpa/datatables/qrepository/QUserRepositoryTest.java
+++ b/src/test/java/org/springframework/data/jpa/datatables/qrepository/QUserRepositoryTest.java
@@ -242,6 +242,18 @@ public class QUserRepositoryTest {
   }
 
   @Test
+  public void testEmptyMultiFilterOnSameColumn() {
+    DataTablesInput input = getBasicInput();
+
+    input.getColumn("role").setSearchValue("+");
+
+    DataTablesOutput<User> output = userRepository.findAll(input);
+    assertNotNull(output);
+    assertNull(output.getError());
+    assertEquals(24, output.getRecordsFiltered());
+  }
+
+  @Test
   public void testFilterOnManyToOneRelationship() {
     DataTablesInput input = getBasicInput();
 

--- a/src/test/java/org/springframework/data/jpa/datatables/repository/BillRepositoryTest.java
+++ b/src/test/java/org/springframework/data/jpa/datatables/repository/BillRepositoryTest.java
@@ -68,6 +68,17 @@ public class BillRepositoryTest {
   }
 
   @Test
+  public void testFilterIsNullWithSeparator() {
+    DataTablesInput input = getBasicInput();
+
+    input.getColumn("hasBeenPayed").setSearchValue("NULL+");
+    DataTablesOutput<Bill> output = billRepository.findAll(input);
+    assertNotNull(output);
+    assertNull(output.getError());
+    assertEquals(1, output.getRecordsFiltered());
+  }
+
+  @Test
   public void testBooleanFilter2() {
     DataTablesInput input = getBasicInput();
 

--- a/src/test/java/org/springframework/data/jpa/datatables/repository/UserRepositoryTest.java
+++ b/src/test/java/org/springframework/data/jpa/datatables/repository/UserRepositoryTest.java
@@ -239,6 +239,18 @@ public class UserRepositoryTest {
   }
 
   @Test
+  public void testEmptyMultiFilterOnSameColumn() {
+    DataTablesInput input = getBasicInput();
+
+    input.getColumn("role").setSearchValue("+");
+
+    DataTablesOutput<User> output = userRepository.findAll(input);
+    assertNotNull(output);
+    assertNull(output.getError());
+    assertEquals(24, output.getRecordsFiltered());
+  }
+
+  @Test
   public void testFilterOnManyToOneRelationship() {
     DataTablesInput input = getBasicInput();
 


### PR DESCRIPTION
Previously, searching with "+" threw SQLException on (at least) Postgres and MySQL.

Closes #54 