### PR TITLE
Allow classes to compile and run with hibernate 5.2.11 as well

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,8 @@
 		<maven.compiler.source>${java.version}</maven.compiler.source>
 		<maven.compiler.target>${java.version}</maven.compiler.target>
 		<source.encoding>UTF-8</source.encoding>
+		<!--<hibernate.version>5.2.10.Final</hibernate.version>-->
+		<hibernate.version>5.0.11.Final</hibernate.version>
 	</properties>
 
 	<dependencyManagement>
@@ -127,10 +129,12 @@
 		<dependency>
 			<groupId>org.hibernate</groupId>
 			<artifactId>hibernate-core</artifactId>
+			<version>${hibernate.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.hibernate</groupId>
 			<artifactId>hibernate-entitymanager</artifactId>
+			<version>${hibernate.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.hibernate</groupId>


### PR DESCRIPTION
Hello,

We have a spring-boot project where we force Hibernate to newer version 5.2.11.Final and it seems that some classes you are importing have changed their package.

I forked and used a bit of reflection to support both class names.

I'm not sure it is the perfect approach but i works now with both hibernate versions.

Would you accept that pull request or at least do you plan using newer version of Hibernate ?
