### PR TITLE
ci: use openjdk8 instead of oraclejdk8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,17 @@
 sudo: false
 language: java
 jdk:
-  - oraclejdk8
+  - openjdk8
 services:
   - mysql
-  - pgsql
+  - postgresql
 matrix:
   include:
-  - jdk: oraclejdk8
+  - jdk: openjdk8
     env: DB=h2
-  - jdk: oraclejdk8
+  - jdk: openjdk8
     env: DB=mysql
-  - jdk: oraclejdk8
+  - jdk: openjdk8
     env: DB=pgsql
 
 script: mvn test -Dspring.profiles.active=$DB


### PR DESCRIPTION
In order to fix the failing build in Travis CI: https://travis-ci.community/t/install-of-oracle-jdk-8-failing/3038/8