### PR TITLE
Use QueryDSL from io.github.openfeign instead of com.querydsl

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -106,20 +106,20 @@
 			<artifactId>hibernate-core</artifactId>
 			<version>6.1.4.Final</version>
 		</dependency>
+
+		<!-- QueryDSL -->
 		<dependency>
-			<groupId>com.querydsl</groupId>
+			<groupId>io.github.openfeign.querydsl</groupId>
 			<artifactId>querydsl-apt</artifactId>
-			<version>5.0.0</version>
 			<classifier>jakarta</classifier>
+			<version>6.10.1</version>
 		</dependency>
-
 		<dependency>
-			<groupId>com.querydsl</groupId>
+			<groupId>io.github.openfeign.querydsl</groupId>
 			<artifactId>querydsl-jpa</artifactId>
-			<version>5.0.0</version>
-			<classifier>jakarta</classifier>
+			<version>6.10.1</version>
 		</dependency>
-
+		
 		<dependency>
 			<groupId>jakarta.annotation</groupId>
 			<artifactId>jakarta.annotation-api</artifactId>


### PR DESCRIPTION
Hello, 

The versions of com.querydsl.QueryDSL <= 5.1.0 are affected by CVE-2024-49203. 

It can't be expected that the mentioned CVE will be fixed, as the original package is hardly maintained anymore. I would suggest switching to the OpenFeign fork permanently to get rid of the CVE.

https://github.com/OpenFeign/querydsl