### PR TITLE
dep: Update Spring Boot to 3.4.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
 			<dependency>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-dependencies</artifactId>
-				<version>3.2.4</version>
+				<version>3.4.0</version>
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>

--- a/src/main/java/org/springframework/data/jpa/datatables/GlobalFilter.java
+++ b/src/main/java/org/springframework/data/jpa/datatables/GlobalFilter.java
@@ -9,6 +9,7 @@ import jakarta.persistence.criteria.CriteriaBuilder;
 import jakarta.persistence.criteria.Expression;
 import jakarta.persistence.criteria.From;
 import jakarta.persistence.criteria.Predicate;
+import org.hibernate.query.criteria.JpaExpression;
 
 /**
  * Filter which creates a basic "WHERE ... LIKE ..." clause
@@ -42,7 +43,7 @@ class GlobalFilter implements Filter {
         if (expression.getJavaType() == String.class) {
             return (Expression<String>) expression;
         } else {
-            return expression.as(String.class);
+            return ((JpaExpression<?>) expression).cast(String.class);
         }
     }
 


### PR DESCRIPTION
Related to #166
Expression.as() doesn’t do anymore a real type conversions. Workaround with JpaExpression and cast.

Like mentioned in December with the new Hibernate 6.6 Version the type cast for the like queries are not working anymore, the workaround is to perform a cast as a JpaExpression and call the Cast Method.